### PR TITLE
Don't error out when not upgrading the library

### DIFF
--- a/Shim.lua
+++ b/Shim.lua
@@ -1,5 +1,9 @@
 local WagoAnalyticsShim = LibStub:NewLibrary("WagoAnalytics", 2)
 
+if not WagoAnalyticsShim then
+	return
+end
+
 function WagoAnalyticsShim:Register(wagoID)
 	local WagoAnalytics = WagoAnalytics
 	if WagoAnalytics then


### PR DESCRIPTION
Fixes #3. The NewLibrary function will return nil if the minor version supplied is <= the currently loaded minor version of the library.

The library should handle this by just returning and doing nothing else.