### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ In your plugin's `.pkgmeta` file, add the following:
 
 ```
 externals:
-  libs/WagoAnalytics:
-    url: https://github.com/wagoio/WagoAnalytics.git
+  libs/WagoAnalyticsShim:
+    url: https://github.com/wagoio/WagoAnalyticsShim.git
     branch: main
 ```
 
@@ -11,5 +11,5 @@ And in your `.toc` file, add the following:
 ```
 ## OptionalDependencies: WagoAnalytics
 
-libs/WagoAnalytics/Shim.lua
+libs\WagoAnalyticsShim\Shim.lua
 ```


### PR DESCRIPTION
The instructions in the README were pointing to the Git repository for the analytics addon itself rather than the shim library.

Additionally the TOC snippet was using "/" delimiters for paths; generally it's recommended to use "\\" delimiters to avoid a few issues with the game client and its handling of such paths: https://wowpedia.fandom.com/wiki/TOC_format#Basic_rules

While the issue described there wouldn't have impacted this library, having things consistently documented with the correct path delimiter avoids cases where users end up copy-pasting lines and loading XML files with the wrong delimiter and run into issues as a result.