### PR TITLE
[Fix] Fixed `GetAddOnMetadata` reference

### DIFF
--- a/Shim.lua
+++ b/Shim.lua
@@ -1,5 +1,7 @@
 local WagoAnalyticsShim = LibStub:NewLibrary("WagoAnalytics", 2)
 
+local GetAddOnMetadata = C_AddOns and C_AddOns.GetAddOnMetadata or GetAddOnMetadata
+
 if not WagoAnalyticsShim then
 	return
 end


### PR DESCRIPTION
- Fixes a small deprecation, which would otherwise trigger an error in 11.0